### PR TITLE
Ensure Discord bot replies use embeds without mentions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Discord bot token
+BOT_TOKEN=your_bot_token_here
+
+# Discord application (client) ID
+CLIENT_ID=your_client_id_here
+
+# (Optional) Guild ID for registering guild-specific slash commands
+GUILD_ID=your_guild_id_here
+
+# Channel ID that should receive Git update notifications
+UPDATE_CHANNEL_ID=your_channel_id_here
+
+# Prefix for text-based commands
+COMMAND_PREFIX=!
+
+# Interval in minutes for checking remote Git updates
+GIT_POLL_INTERVAL_MINUTES=5

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+.env
+npm-debug.log*
+.DS_Store
+
+# Logs
+logs/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,89 @@
-# Logs
+# Discord Bot with Git Update Automation
+
+This project provides a Discord bot written in JavaScript (Node.js) that supports both prefix-based text commands and modern slash commands. It also includes a Git monitoring service that watches the repository for remote updates, posts a notification to a dedicated Discord channel, and (upon confirmation) automatically pulls the latest changes, pushes them upstream, and restarts the bot.
+
+## Features
+
+- **Text commands** with a configurable prefix (default: `!`).
+- **Slash commands** powered by Discord's interactions API.
+- **GitHub update monitor** that checks for new commits on the upstream branch and announces them in a fixed channel.
+- **One-click updates**: authorised users can confirm the update via a button, triggering `git pull`, `git push`, and a clean restart of the bot worker.
+- **Structured codebase** with clear separation of configuration, commands, events, services, and utilities.
+
+## Getting started
+
+### Prerequisites
+
+- Node.js 18 or later.
+- A Discord application with a bot token.
+- A Git repository with a configured upstream remote (e.g. `origin/main`).
+
+> **Note:** Installing dependencies from the public npm registry may require additional configuration in restricted environments.
+
+### Installation
+
+1. Clone the repository and install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Create a `.env` file based on the provided example:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+3. Update `.env` with your Discord credentials and configuration:
+
+   - `BOT_TOKEN`: Bot token from the Discord developer portal.
+   - `CLIENT_ID`: Application (client) ID.
+   - `GUILD_ID`: (Optional) Guild ID for faster slash-command deployment during development.
+   - `UPDATE_CHANNEL_ID`: Channel ID that should receive Git update notifications.
+   - `COMMAND_PREFIX`: Prefix for text commands (defaults to `!`).
+   - `GIT_POLL_INTERVAL_MINUTES`: How often to poll for remote changes (defaults to 5 minutes).
+
+4. Deploy slash commands (run again whenever slash commands change):
+
+   ```bash
+   npm run deploy:commands
+   ```
+
+5. Start the bot:
+
+   ```bash
+   npm start
+   ```
+
+## Project structure
+
+```
+src/
+├── bot/
+│   ├── bot.js                # Core bot logic
+│   ├── commands/             # Text and slash command implementations
+│   ├── events/               # Discord event bindings
+│   ├── loaders/              # Helpers for loading commands
+│   ├── services/             # Git monitoring service
+│   └── util/                 # Logger utility
+├── config/                   # Environment configuration loader
+├── index.js                  # Supervisor that restarts the worker on demand
+└── worker.js                 # Actual bot worker process
+```
+
+## Git update workflow
+
+1. The `GitMonitor` service periodically executes `git fetch`/`git status` to check if the local repository is behind the upstream branch.
+2. When the bot detects that it is behind, it sends a message with a confirmation button to `UPDATE_CHANNEL_ID`.
+3. A user with the **Manage Server** permission can click the button to execute the update.
+4. The bot runs `git pull` followed by `git push`. On success, the confirmation message is updated and the bot restarts automatically via the supervisor (`src/index.js`).
+
+## Adding commands
+
+- **Text commands**: add a new file to `src/bot/commands/text`. Export an object with `name`, `description`, and `execute`.
+- **Slash commands**: add a new file to `src/bot/commands/slash`. Export an object with `data` (a `SlashCommandBuilder`) and `execute`.
+- After modifying slash commands, run `npm run deploy:commands`.
+
+## License
+
+MIT

--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -1,0 +1,34 @@
+const path = require('node:path');
+const { REST, Routes } = require('discord.js');
+
+const config = require('./src/config');
+const { loadSlashCommands } = require('./src/bot/loaders/commandLoader');
+const logger = require('./src/bot/util/logger');
+
+(async () => {
+  if (!config.token || !config.clientId) {
+    logger.error('BOT_TOKEN and CLIENT_ID must be set before deploying slash commands.');
+    process.exit(1);
+    return;
+  }
+
+  const slashDirectory = path.join(__dirname, 'src', 'bot', 'commands', 'slash');
+  const slashCommands = loadSlashCommands(slashDirectory).map((command) => command.data.toJSON());
+
+  const rest = new REST({ version: '10' }).setToken(config.token);
+
+  try {
+    logger.info(`Deploying ${slashCommands.length} slash commands...`);
+
+    if (config.guildId) {
+      await rest.put(Routes.applicationGuildCommands(config.clientId, config.guildId), { body: slashCommands });
+      logger.info('Slash commands registered for guild testing.');
+    } else {
+      await rest.put(Routes.applicationCommands(config.clientId), { body: slashCommands });
+      logger.info('Slash commands registered globally.');
+    }
+  } catch (error) {
+    logger.error('Failed to deploy slash commands:', error);
+    process.exit(1);
+  }
+})();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "logs-discord-bot",
+  "version": "1.0.0",
+  "description": "Discord bot with text/slash commands and GitHub update notifier.",
+  "main": "src/index.js",
+  "type": "commonjs",
+  "scripts": {
+    "start": "node ./src/index.js",
+    "start:worker": "node ./src/worker.js",
+    "deploy:commands": "node ./deploy-commands.js"
+  },
+  "keywords": [
+    "discord",
+    "bot"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "discord.js": "^14.15.3",
+    "dotenv": "^16.4.5",
+    "simple-git": "^3.27.0"
+  }
+}

--- a/src/bot/bot.js
+++ b/src/bot/bot.js
@@ -1,0 +1,157 @@
+const { EventEmitter } = require('node:events');
+const path = require('node:path');
+const {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  Client,
+  Collection,
+  GatewayIntentBits,
+} = require('discord.js');
+
+const logger = require('./util/logger');
+const GitMonitor = require('./services/gitMonitor');
+const { loadTextCommands, loadSlashCommands } = require('./loaders/commandLoader');
+const { createEmbed } = require('./util/replies');
+
+class Bot extends EventEmitter {
+  constructor(config) {
+    super();
+    this.config = config;
+    this.client = new Client({
+      intents: [
+        GatewayIntentBits.Guilds,
+        GatewayIntentBits.GuildMessages,
+        GatewayIntentBits.MessageContent,
+      ],
+    });
+
+    this.textCommands = new Collection();
+    this.slashCommands = new Collection();
+
+    this.gitMonitor = new GitMonitor({
+      repoPath: process.cwd(),
+      intervalMinutes: this.config.gitPollIntervalMinutes,
+      logger,
+    });
+
+    this.pendingUpdateMessageId = null;
+
+    this.registerGitEvents();
+    this.registerClientEvents();
+  }
+
+  loadCommands() {
+    const textPath = path.join(__dirname, 'commands', 'text');
+    const slashPath = path.join(__dirname, 'commands', 'slash');
+
+    const textCommands = loadTextCommands(textPath);
+    const slashCommands = loadSlashCommands(slashPath);
+
+    this.textCommands.clear();
+    for (const [name, command] of textCommands.entries()) {
+      this.textCommands.set(name, command);
+    }
+
+    this.slashCommands.clear();
+    for (const command of slashCommands) {
+      this.slashCommands.set(command.data.name, command);
+    }
+
+    logger.info(`Loaded ${this.textCommands.size} text commands and ${this.slashCommands.size} slash commands.`);
+  }
+
+  registerClientEvents() {
+    const readyHandler = require('./events/ready');
+    const messageHandler = require('./events/messageCreate');
+    const interactionHandler = require('./events/interactionCreate');
+
+    readyHandler({ client: this.client, logger, slashCommands: Array.from(this.slashCommands.values()) });
+    messageHandler({
+      client: this.client,
+      logger,
+      textCommands: this.textCommands,
+      prefix: this.config.commandPrefix,
+    });
+    interactionHandler({
+      client: this.client,
+      logger,
+      slashCommands: this.slashCommands,
+      gitMonitor: this.gitMonitor,
+      requestRestart: () => this.emit('restartRequested'),
+      updateChannelId: this.config.updateChannelId,
+    });
+  }
+
+  registerGitEvents() {
+    this.gitMonitor.on('updateAvailable', async (status) => {
+      if (!this.client.isReady()) {
+        return;
+      }
+
+      if (!this.config.updateChannelId) {
+        logger.warn('Git updates detected, but UPDATE_CHANNEL_ID is not set.');
+        return;
+      }
+
+      try {
+        const channel = await this.client.channels.fetch(this.config.updateChannelId);
+        if (!channel || !channel.isTextBased()) {
+          logger.warn('Configured update channel is not accessible or not text-based.');
+          return;
+        }
+
+        if (this.pendingUpdateMessageId) {
+          const existingMessage = await channel.messages.fetch(this.pendingUpdateMessageId).catch(() => null);
+          if (existingMessage) {
+            return;
+          }
+          this.pendingUpdateMessageId = null;
+        }
+
+        const button = new ButtonBuilder()
+          .setCustomId(GitMonitor.UPDATE_BUTTON_ID)
+          .setLabel('Pull & Restart')
+          .setStyle(ButtonStyle.Primary);
+
+        const row = new ActionRowBuilder().addComponents(button);
+
+        const notificationEmbed = createEmbed({
+          title: '🚨 Repository update detected!',
+          description: [
+            `The bot is **${status.behind}** commit(s) behind the upstream branch.`,
+            'Click the button below to pull the latest changes, push them upstream, and restart the bot.',
+          ].join('\n'),
+        });
+
+        const message = await channel.send({ embeds: [notificationEmbed], components: [row] });
+        this.pendingUpdateMessageId = message.id;
+        logger.info(`Update notification sent to channel ${channel.id}.`);
+      } catch (error) {
+        logger.error('Failed to send update notification message:', error);
+      }
+    });
+  }
+
+  async start() {
+    this.loadCommands();
+
+    this.client.once('ready', () => {
+      if (this.config.updateChannelId) {
+        this.gitMonitor.start();
+      } else {
+        logger.warn('UPDATE_CHANNEL_ID is not set; git update notifications are disabled.');
+      }
+    });
+
+    await this.client.login(this.config.token);
+  }
+
+  async stop() {
+    this.gitMonitor.stop();
+    this.client.removeAllListeners();
+    await this.client.destroy();
+  }
+}
+
+module.exports = Bot;

--- a/src/bot/commands/slash/gitstatus.js
+++ b/src/bot/commands/slash/gitstatus.js
@@ -1,0 +1,41 @@
+const { SlashCommandBuilder } = require('discord.js');
+const simpleGit = require('simple-git');
+const path = require('node:path');
+const { createEmbed } = require('../../util/replies');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('gitstatus')
+    .setDescription('Show the current Git synchronization status.'),
+  async execute(interaction) {
+    await interaction.deferReply({ ephemeral: true });
+
+    try {
+      const git = simpleGit({ baseDir: path.resolve(process.cwd()) });
+      const status = await git.status();
+
+      const embed = createEmbed({
+        title: 'Repository status',
+        description: 'Current git synchronization summary',
+        fields: [
+          { name: 'Branch', value: status.current || 'Unknown', inline: true },
+          { name: 'Tracking', value: status.tracking || 'None', inline: true },
+          { name: 'Ahead', value: String(status.ahead || 0), inline: true },
+          { name: 'Behind', value: String(status.behind || 0), inline: true },
+          { name: 'Changes', value: status.files.length.toString(), inline: true },
+        ],
+      });
+
+      await interaction.editReply({ embeds: [embed] });
+    } catch (error) {
+      const errorEmbed = createEmbed({
+        title: 'Git status error',
+        description: `Failed to read git status: ${error.message}`,
+      });
+
+      await interaction.editReply({
+        embeds: [errorEmbed],
+      });
+    }
+  },
+};

--- a/src/bot/commands/slash/ping.js
+++ b/src/bot/commands/slash/ping.js
@@ -1,0 +1,18 @@
+const { SlashCommandBuilder } = require('discord.js');
+const { createEmbed } = require('../../util/replies');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('ping')
+    .setDescription('Check the bot\'s latency.'),
+  async execute(interaction) {
+    const sent = await interaction.reply({
+      embeds: [createEmbed({ description: 'Pinging... ⏱️' })],
+      fetchReply: true,
+    });
+    const latency = sent.createdTimestamp - interaction.createdTimestamp;
+    await interaction.editReply({
+      embeds: [createEmbed({ description: `Pong! Round-trip latency: **${latency}ms**.` })],
+    });
+  },
+};

--- a/src/bot/commands/text/help.js
+++ b/src/bot/commands/text/help.js
@@ -1,0 +1,18 @@
+const { createEmbed, replyWithEmbed } = require('../../util/replies');
+
+module.exports = {
+  name: 'help',
+  description: 'List available text commands.',
+  async execute({ message, textCommands, prefix }) {
+    const commandList = Array.from(textCommands.values())
+      .map((command) => `${prefix}${command.name} - ${command.description || 'No description provided.'}`)
+      .join('\n');
+
+    const embed = createEmbed({
+      title: 'Available text commands',
+      description: commandList || 'No commands are currently available.',
+    });
+
+    await replyWithEmbed(message, embed);
+  },
+};

--- a/src/bot/commands/text/ping.js
+++ b/src/bot/commands/text/ping.js
@@ -1,0 +1,18 @@
+const { createEmbed, replyWithEmbed } = require('../../util/replies');
+
+module.exports = {
+  name: 'ping',
+  description: "Check the bot's latency.",
+  async execute({ message }) {
+    const sent = await replyWithEmbed(message, {
+      description: 'Pinging... ⏱️',
+    });
+
+    const latency = sent.createdTimestamp - message.createdTimestamp;
+    const resultEmbed = createEmbed({
+      description: `Pong! Round-trip latency: **${latency}ms**.`,
+    });
+
+    await sent.edit({ embeds: [resultEmbed] });
+  },
+};

--- a/src/bot/events/interactionCreate.js
+++ b/src/bot/events/interactionCreate.js
@@ -1,0 +1,94 @@
+const { PermissionFlagsBits, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+const { createEmbed } = require('../util/replies');
+const GitMonitor = require('../services/gitMonitor');
+
+module.exports = ({ client, logger, slashCommands, gitMonitor, requestRestart, updateChannelId }) => {
+  client.on('interactionCreate', async (interaction) => {
+    if (interaction.isChatInputCommand()) {
+      const command = slashCommands.get(interaction.commandName);
+      if (!command) {
+        return;
+      }
+
+      try {
+        await command.execute(interaction);
+      } catch (error) {
+        logger.error(`Error executing slash command ${interaction.commandName}:`, error);
+        const errorEmbed = createEmbed({
+          title: 'Command error',
+          description: 'There was an error while executing this command.',
+        });
+        const replyContent = { embeds: [errorEmbed], ephemeral: true };
+
+        if (interaction.replied || interaction.deferred) {
+          await interaction.followUp(replyContent);
+        } else {
+          await interaction.reply(replyContent);
+        }
+      }
+      return;
+    }
+
+    if (interaction.isButton() && interaction.customId === GitMonitor.UPDATE_BUTTON_ID) {
+      if (updateChannelId && interaction.channelId !== updateChannelId) {
+        return;
+      }
+
+      if (!interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild)) {
+        const permissionEmbed = createEmbed({
+          title: 'Permission required',
+          description: 'You need the **Manage Server** permission to confirm updates.',
+        });
+
+        await interaction.reply({
+          embeds: [permissionEmbed],
+          ephemeral: true,
+        });
+        return;
+      }
+
+      await interaction.deferReply({ ephemeral: true });
+
+      try {
+        const { pullResult, pushResult } = await gitMonitor.applyRemoteUpdates();
+        const changeCount = pullResult?.summary?.changes ?? 0;
+        const pushStatus = pushResult?.pushed?.length ? 'pushed' : 'up-to-date';
+
+        const successEmbed = createEmbed({
+          title: 'Update applied',
+          description: `Pull complete (**${changeCount}** changes). Push status: **${pushStatus}**. Restarting...`,
+        });
+
+        await interaction.editReply({
+          embeds: [successEmbed],
+        });
+
+        if (interaction.message?.components?.length) {
+          const [row] = interaction.message.components;
+          const [button] = row.components;
+          if (button) {
+            const disabledButton = ButtonBuilder.from(button)
+              .setDisabled(true)
+              .setStyle(ButtonStyle.Success)
+              .setLabel('Updated');
+
+            const disabledRow = new ActionRowBuilder().addComponents(disabledButton);
+            await interaction.message.edit({ components: [disabledRow] });
+          }
+        }
+
+        requestRestart();
+      } catch (error) {
+        logger.error('Failed to apply git updates:', error);
+        const failureEmbed = createEmbed({
+          title: 'Update failed',
+          description: `Failed to update: ${error.message}`,
+        });
+
+        await interaction.editReply({
+          embeds: [failureEmbed],
+        });
+      }
+    }
+  });
+};

--- a/src/bot/events/messageCreate.js
+++ b/src/bot/events/messageCreate.js
@@ -1,0 +1,36 @@
+const { createEmbed, replyWithEmbed } = require('../util/replies');
+
+module.exports = ({ client, logger, textCommands, prefix }) => {
+  client.on('messageCreate', async (message) => {
+    if (message.author.bot || !message.content.startsWith(prefix)) {
+      return;
+    }
+
+    const args = message.content.slice(prefix.length).trim().split(/\s+/);
+    const commandName = args.shift()?.toLowerCase();
+
+    if (!commandName) {
+      return;
+    }
+
+    const command = textCommands.get(commandName);
+
+    if (!command) {
+      return;
+    }
+
+    try {
+      await command.execute({ message, args, client, logger, textCommands, prefix });
+    } catch (error) {
+      logger.error(`Error executing text command ${commandName}:`, error);
+      if (message.channel) {
+        const errorEmbed = createEmbed({
+          title: 'Command error',
+          description: 'There was an error while executing that command.',
+        });
+
+        await replyWithEmbed(message, errorEmbed);
+      }
+    }
+  });
+};

--- a/src/bot/events/ready.js
+++ b/src/bot/events/ready.js
@@ -1,0 +1,6 @@
+module.exports = ({ client, logger, slashCommands }) => {
+  client.once('ready', async () => {
+    logger.info(`Logged in as ${client.user.tag}`);
+    logger.info(`Loaded ${slashCommands.length} slash commands.`);
+  });
+};

--- a/src/bot/loaders/commandLoader.js
+++ b/src/bot/loaders/commandLoader.js
@@ -1,0 +1,55 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+function loadCommands(directory) {
+  const commands = new Map();
+
+  if (!fs.existsSync(directory)) {
+    return commands;
+  }
+
+  const files = fs.readdirSync(directory).filter((file) => file.endsWith('.js'));
+
+  for (const file of files) {
+    const filepath = path.join(directory, file);
+    delete require.cache[require.resolve(filepath)];
+    const command = require(filepath);
+
+    if (!command || !command.name || typeof command.execute !== 'function') {
+      continue;
+    }
+
+    commands.set(command.name, command);
+  }
+
+  return commands;
+}
+
+function loadSlashCommands(directory) {
+  const commands = [];
+
+  if (!fs.existsSync(directory)) {
+    return commands;
+  }
+
+  const files = fs.readdirSync(directory).filter((file) => file.endsWith('.js'));
+
+  for (const file of files) {
+    const filepath = path.join(directory, file);
+    delete require.cache[require.resolve(filepath)];
+    const command = require(filepath);
+
+    if (!command || !command.data || typeof command.execute !== 'function') {
+      continue;
+    }
+
+    commands.push(command);
+  }
+
+  return commands;
+}
+
+module.exports = {
+  loadTextCommands: loadCommands,
+  loadSlashCommands,
+};

--- a/src/bot/services/gitMonitor.js
+++ b/src/bot/services/gitMonitor.js
@@ -1,0 +1,71 @@
+const { EventEmitter } = require('node:events');
+const path = require('node:path');
+const simpleGit = require('simple-git');
+
+const UPDATE_BUTTON_ID = 'git-update-confirm';
+
+class GitMonitor extends EventEmitter {
+  constructor({ repoPath = process.cwd(), intervalMinutes = 5, logger }) {
+    super();
+    this.repoPath = path.resolve(repoPath);
+    this.intervalMs = Math.max(intervalMinutes, 1) * 60 * 1000;
+    this.logger = logger;
+    this.git = simpleGit({ baseDir: this.repoPath });
+    this.timer = null;
+    this.notified = false;
+  }
+
+  async checkForRemoteChanges() {
+    try {
+      await this.git.fetch();
+      const status = await this.git.status();
+
+      if ((status.behind || 0) > 0 && !this.notified) {
+        this.notified = true;
+        this.logger.info('Remote updates detected.');
+        this.emit('updateAvailable', status);
+      } else if ((status.behind || 0) === 0) {
+        this.notified = false;
+      }
+    } catch (error) {
+      this.logger.error('Failed to check for remote git updates:', error);
+    }
+  }
+
+  start() {
+    if (this.timer) {
+      return;
+    }
+
+    this.logger.info(`Starting Git monitor for ${this.repoPath} (every ${this.intervalMs / 60000} minutes).`);
+    this.timer = setInterval(() => {
+      void this.checkForRemoteChanges();
+    }, this.intervalMs);
+
+    void this.checkForRemoteChanges();
+  }
+
+  stop() {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  async applyRemoteUpdates() {
+    try {
+      await this.git.fetch();
+      const pullResult = await this.git.pull();
+      const pushResult = await this.git.push();
+      this.notified = false;
+      return { pullResult, pushResult };
+    } catch (error) {
+      this.logger.error('Failed to apply remote git updates:', error);
+      throw error;
+    }
+  }
+}
+
+GitMonitor.UPDATE_BUTTON_ID = UPDATE_BUTTON_ID;
+
+module.exports = GitMonitor;

--- a/src/bot/util/logger.js
+++ b/src/bot/util/logger.js
@@ -1,0 +1,15 @@
+function timestamp() {
+  return new Date().toISOString();
+}
+
+module.exports = {
+  info(message, ...meta) {
+    console.log(`[${timestamp()}] [INFO] ${message}`, ...meta);
+  },
+  warn(message, ...meta) {
+    console.warn(`[${timestamp()}] [WARN] ${message}`, ...meta);
+  },
+  error(message, ...meta) {
+    console.error(`[${timestamp()}] [ERROR] ${message}`, ...meta);
+  },
+};

--- a/src/bot/util/replies.js
+++ b/src/bot/util/replies.js
@@ -1,0 +1,58 @@
+const { EmbedBuilder } = require('discord.js');
+
+const DEFAULT_COLOR = 0x2b2d31;
+
+function createEmbed(options = {}) {
+  const { title, description, fields, color = DEFAULT_COLOR, footer, timestamp = true } = options;
+  const embed = new EmbedBuilder();
+
+  if (title) {
+    embed.setTitle(title);
+  }
+
+  if (description) {
+    embed.setDescription(description);
+  }
+
+  if (Array.isArray(fields) && fields.length > 0) {
+    embed.addFields(fields);
+  }
+
+  if (color) {
+    embed.setColor(color);
+  }
+
+  if (footer) {
+    embed.setFooter(footer);
+  }
+
+  if (timestamp) {
+    embed.setTimestamp(new Date());
+  }
+
+  return embed;
+}
+
+function ensureEmbed(embedOrOptions) {
+  if (embedOrOptions instanceof EmbedBuilder) {
+    return embedOrOptions;
+  }
+
+  return createEmbed(embedOrOptions);
+}
+
+function replyWithEmbed(message, embedOrOptions, extraOptions = {}) {
+  const embed = ensureEmbed(embedOrOptions);
+
+  return message.reply({
+    embeds: [embed],
+    allowedMentions: { repliedUser: false },
+    ...extraOptions,
+  });
+}
+
+module.exports = {
+  DEFAULT_COLOR,
+  createEmbed,
+  replyWithEmbed,
+};

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,0 +1,20 @@
+const path = require('node:path');
+const dotenv = require('dotenv');
+
+dotenv.config({ path: path.resolve(process.cwd(), '.env') });
+
+function numberFromEnv(value, fallback) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+const config = {
+  token: process.env.BOT_TOKEN || '',
+  clientId: process.env.CLIENT_ID || '',
+  guildId: process.env.GUILD_ID || '',
+  updateChannelId: process.env.UPDATE_CHANNEL_ID || '',
+  commandPrefix: process.env.COMMAND_PREFIX || '!',
+  gitPollIntervalMinutes: numberFromEnv(process.env.GIT_POLL_INTERVAL_MINUTES, 5),
+};
+
+module.exports = config;

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,48 @@
+const { spawn } = require('node:child_process');
+const path = require('node:path');
+
+const WORKER_PATH = path.join(__dirname, 'worker.js');
+const RESTART_CODE = 5;
+
+let childProcess = null;
+
+function startWorker() {
+  childProcess = spawn(process.execPath, [WORKER_PATH], {
+    stdio: 'inherit',
+  });
+
+  childProcess.on('exit', (code, signal) => {
+    childProcess = null;
+
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+
+    if (code === RESTART_CODE) {
+      console.log('[Launcher] Restart requested. Spawning a new worker...');
+      startWorker();
+      return;
+    }
+
+    if (code === 0) {
+      console.log('[Launcher] Worker stopped gracefully.');
+      process.exit(0);
+      return;
+    }
+
+    console.error(`[Launcher] Worker exited with code ${code}.`);
+    process.exit(code ?? 1);
+  });
+}
+
+function handleShutdown() {
+  if (childProcess) {
+    childProcess.kill('SIGINT');
+  }
+}
+
+process.on('SIGINT', handleShutdown);
+process.on('SIGTERM', handleShutdown);
+
+startWorker();

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,0 +1,40 @@
+const Bot = require('./bot/bot');
+const config = require('./config');
+const logger = require('./bot/util/logger');
+
+const RESTART_CODE = 5;
+
+(async () => {
+  if (!config.token) {
+    logger.error('BOT_TOKEN is not set. Please configure your environment variables.');
+    process.exit(1);
+    return;
+  }
+
+  const bot = new Bot(config);
+
+  const shutdown = async (exitCode = 0) => {
+    try {
+      await bot.stop();
+    } catch (error) {
+      logger.error('Error while stopping the bot:', error);
+    } finally {
+      process.exit(exitCode);
+    }
+  };
+
+  bot.on('restartRequested', async () => {
+    logger.info('Restart requested. Exiting worker so launcher can restart.');
+    await shutdown(RESTART_CODE);
+  });
+
+  process.on('SIGINT', () => shutdown(0));
+  process.on('SIGTERM', () => shutdown(0));
+
+  try {
+    await bot.start();
+  } catch (error) {
+    logger.error('Failed to start the bot:', error);
+    await shutdown(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- add a shared helper for building embeds and replying without pinging users
- convert text command handlers, slash command errors, and git update notifications to use embeds
- ensure git update confirmations and status checks surface their messaging through embeds

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deb11fc0b8832fb5702a43c061accc