### PR TITLE
Improve git monitor update notification UX

### DIFF
--- a/src/bot/events/interactionCreate.js
+++ b/src/bot/events/interactionCreate.js
@@ -1,8 +1,8 @@
-const { PermissionFlagsBits, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+const { PermissionFlagsBits } = require('discord.js');
 const { createEmbed } = require('../util/replies');
 const GitMonitor = require('../services/gitMonitor');
 
-module.exports = ({ client, logger, slashCommands, gitMonitor, requestRestart, updateChannelId }) => {
+module.exports = ({ client, logger, slashCommands, gitMonitor, requestRestart, updateChannelId, clearUpdatePrompt }) => {
   client.on('interactionCreate', async (interaction) => {
     if (interaction.isChatInputCommand()) {
       const command = slashCommands.get(interaction.commandName);
@@ -29,66 +29,130 @@ module.exports = ({ client, logger, slashCommands, gitMonitor, requestRestart, u
       return;
     }
 
-    if (interaction.isButton() && interaction.customId === GitMonitor.UPDATE_BUTTON_ID) {
-      if (updateChannelId && interaction.channelId !== updateChannelId) {
-        return;
-      }
+    if (!interaction.isButton()) {
+      return;
+    }
 
-      if (!interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild)) {
-        const permissionEmbed = createEmbed({
-          title: 'Permission required',
-          description: 'You need the **Manage Server** permission to confirm updates.',
+    const isConfirm = interaction.customId === GitMonitor.UPDATE_CONFIRM_BUTTON_ID;
+    const isDecline = interaction.customId === GitMonitor.UPDATE_DECLINE_BUTTON_ID;
+
+    if (!isConfirm && !isDecline) {
+      return;
+    }
+
+    if (updateChannelId && interaction.channelId !== updateChannelId) {
+      return;
+    }
+
+    if (!interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild)) {
+      const permissionEmbed = createEmbed({
+        title: 'Permission required',
+        description: 'You need the **Manage Server** permission to manage repository updates.',
+      });
+
+      if (interaction.replied || interaction.deferred) {
+        await interaction.followUp({
+          embeds: [permissionEmbed],
+          ephemeral: true,
         });
-
+      } else {
         await interaction.reply({
           embeds: [permissionEmbed],
           ephemeral: true,
         });
-        return;
       }
 
-      await interaction.deferReply({ ephemeral: true });
+      return;
+    }
 
-      try {
-        const { pullResult, pushResult } = await gitMonitor.applyRemoteUpdates();
-        const changeCount = pullResult?.summary?.changes ?? 0;
-        const pushStatus = pushResult?.pushed?.length ? 'pushed' : 'up-to-date';
+    if (isDecline) {
+      await interaction.deferUpdate();
 
-        const successEmbed = createEmbed({
-          title: 'Update applied',
-          description: `Pull complete (**${changeCount}** changes). Push status: **${pushStatus}**. Restarting...`,
-        });
+      const dismissedEmbed = createEmbed({
+        title: 'Update dismissed',
+        description: `The pending repository update was dismissed by **${interaction.user.tag}**.`,
+        color: 0xffa500,
+      });
 
-        await interaction.editReply({
-          embeds: [successEmbed],
-        });
+      await interaction.message.edit({
+        embeds: [dismissedEmbed],
+        components: [],
+      });
 
-        if (interaction.message?.components?.length) {
-          const [row] = interaction.message.components;
-          const [button] = row.components;
-          if (button) {
-            const disabledButton = ButtonBuilder.from(button)
-              .setDisabled(true)
-              .setStyle(ButtonStyle.Success)
-              .setLabel('Updated');
+      await interaction.followUp({
+        embeds: [
+          createEmbed({
+            title: 'Update dismissed',
+            description: 'You can rerun the git monitor when you are ready to update.',
+            color: 0xffa500,
+          }),
+        ],
+        ephemeral: true,
+      });
 
-            const disabledRow = new ActionRowBuilder().addComponents(disabledButton);
-            await interaction.message.edit({ components: [disabledRow] });
-          }
-        }
+      clearUpdatePrompt?.();
+      return;
+    }
 
-        requestRestart();
-      } catch (error) {
-        logger.error('Failed to apply git updates:', error);
-        const failureEmbed = createEmbed({
-          title: 'Update failed',
-          description: `Failed to update: ${error.message}`,
-        });
+    await interaction.deferReply({ ephemeral: true });
 
-        await interaction.editReply({
-          embeds: [failureEmbed],
-        });
-      }
+    try {
+      const { pullResult, pushResult } = await gitMonitor.applyRemoteUpdates();
+      const changeCount = pullResult?.summary?.changes ?? 0;
+      const pushStatus = pushResult?.pushed?.length ? 'pushed' : 'up-to-date';
+      const changeLabel = changeCount === 1 ? 'change' : 'changes';
+
+      const successEmbed = createEmbed({
+        title: 'Update approved',
+        color: 0x3ba55d,
+        description: [
+          `Pulled **${changeCount}** ${changeLabel}.`,
+          `Push status: **${pushStatus}**.`,
+          'The bot is restarting to apply the latest changes.',
+        ].join('\n'),
+      });
+
+      await interaction.editReply({
+        embeds: [successEmbed],
+      });
+
+      const resolvedEmbed = createEmbed({
+        title: 'Update scheduled',
+        description: `Update approved by **${interaction.user.tag}**. The bot will restart shortly.`,
+        color: 0x3ba55d,
+      });
+
+      await interaction.message.edit({
+        embeds: [resolvedEmbed],
+        components: [],
+      });
+
+      requestRestart();
+      clearUpdatePrompt?.();
+    } catch (error) {
+      logger.error('Failed to apply git updates:', error);
+      const failureEmbed = createEmbed({
+        title: 'Update failed',
+        description: `Failed to update: ${error.message}`,
+        color: 0xed4245,
+      });
+
+      await interaction.editReply({
+        embeds: [failureEmbed],
+      });
+
+      const failureNoticeEmbed = createEmbed({
+        title: 'Update attempt failed',
+        description: 'The automated pull could not be completed. Please resolve the issue manually before retrying.',
+        color: 0xed4245,
+      });
+
+      await interaction.message.edit({
+        embeds: [failureNoticeEmbed],
+        components: [],
+      });
+
+      clearUpdatePrompt?.();
     }
   });
 };

--- a/src/bot/services/gitMonitor.js
+++ b/src/bot/services/gitMonitor.js
@@ -2,7 +2,8 @@ const { EventEmitter } = require('node:events');
 const path = require('node:path');
 const simpleGit = require('simple-git');
 
-const UPDATE_BUTTON_ID = 'git-update-confirm';
+const UPDATE_CONFIRM_BUTTON_ID = 'git-update-confirm';
+const UPDATE_DECLINE_BUTTON_ID = 'git-update-decline';
 
 class GitMonitor extends EventEmitter {
   constructor({ repoPath = process.cwd(), intervalMinutes = 5, logger }) {
@@ -66,6 +67,7 @@ class GitMonitor extends EventEmitter {
   }
 }
 
-GitMonitor.UPDATE_BUTTON_ID = UPDATE_BUTTON_ID;
+GitMonitor.UPDATE_CONFIRM_BUTTON_ID = UPDATE_CONFIRM_BUTTON_ID;
+GitMonitor.UPDATE_DECLINE_BUTTON_ID = UPDATE_DECLINE_BUTTON_ID;
 
 module.exports = GitMonitor;


### PR DESCRIPTION
## Summary
- present the git monitor notification with a professional embed and dual actions
- allow admins to approve or dismiss updates and clear the prompt after responding
- update interaction handling to remove action buttons after any response and provide clearer follow-up messaging

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68debf222ea8832fa2f8407ec2376975