### PR TITLE
Simplify latency embed title

### DIFF
--- a/src/bot/util/ping.js
+++ b/src/bot/util/ping.js
@@ -25,7 +25,7 @@ function buildLatencyEmbed({ roundTrip, wsPing }) {
   const state = resolveLatencyState(roundTrip, wsPing);
 
   return createEmbed({
-    title: `${state.emoji} ${state.label} Latency`,
+    title: 'Latency Results',
     description: state.description,
     color: state.color,
     fields: [


### PR DESCRIPTION
## Summary
- replace the latency embed's dynamic title with a consistent "Latency Results"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dec33e8a24832fb7afbf2d7dbd48b8