### PR TITLE
Improve Mongo stats output and git update notifications

### DIFF
--- a/src/bot/bot.js
+++ b/src/bot/bot.js
@@ -136,6 +136,18 @@ class Bot extends EventEmitter {
         const behindCount = status.behind ?? 0;
         const commitLabel = behindCount === 1 ? 'commit' : 'commits';
 
+        const commitSummaries = await this.gitMonitor.getPendingCommitSummaries(status);
+
+        const pendingChangesField = commitSummaries.length
+          ? {
+              name: 'Pending Changes',
+              value: commitSummaries.join('\n'),
+            }
+          : {
+              name: 'Pending Changes',
+              value: 'Unable to load commit summaries.',
+            };
+
         const notificationEmbed = createEmbed({
           title: 'Repository Update Available',
           color: 0x1f6feb,
@@ -159,13 +171,7 @@ class Bot extends EventEmitter {
               value: status.tracking || 'Not configured',
               inline: true,
             },
-            {
-              name: 'Available Actions',
-              value: [
-                '• **Apply Update & Restart** – Pulls the latest changes, pushes them upstream, and restarts the bot.',
-                '• **Dismiss** – Acknowledges this notice until new remote commits are detected.',
-              ].join('\n'),
-            },
+            pendingChangesField,
           ],
         });
 

--- a/src/bot/commands/slash/mongostats.js
+++ b/src/bot/commands/slash/mongostats.js
@@ -1,6 +1,5 @@
 const { SlashCommandBuilder, MessageFlags } = require('discord.js');
 const config = require('../../../config');
-const { createEmbed } = require('../../util/replies');
 
 const ownerIdSet = new Set(config.ownerIds || []);
 const numberFormatter = new Intl.NumberFormat('en-US');
@@ -50,94 +49,44 @@ module.exports = {
     const mongoService = interaction.client.mongoService;
 
     if (!mongoService || !mongoService.isConfigured()) {
-      const embed = createEmbed({
-        title: 'MongoDB not configured',
-        description: 'Set the **MONGODB_URI** environment variable to enable MongoDB features.',
-        color: 0xffa500,
+      await interaction.editReply({
+        content:
+          '**MongoDB not configured**\nSet the **MONGODB_URI** environment variable to enable MongoDB features.',
       });
-
-      await interaction.editReply({ embeds: [embed] });
       return;
     }
 
     try {
       await mongoService.connect();
     } catch (error) {
-      const embed = createEmbed({
-        title: 'MongoDB connection failed',
-        description: `Unable to connect to MongoDB.\n\n\`\`\`${error.message}\`\`\``,
-        color: 0xed4245,
+      await interaction.editReply({
+        content: ['**MongoDB connection failed**', '```', error.message, '```'].join('\n'),
       });
-
-      await interaction.editReply({ embeds: [embed] });
       return;
     }
 
     try {
       const pingMs = await mongoService.ping();
       const stats = await mongoService.getDatabaseStats();
+      const lines = [
+        '**MongoDB status**',
+        '',
+        'Connection: Connected ✅',
+        `Ping: ${pingMs} ms`,
+        `Database: ${stats.db || 'Unknown'}`,
+        `Collections: ${numberFormatter.format(stats.collections ?? 0)}`,
+        `Documents: ${numberFormatter.format(stats.objects ?? 0)}`,
+        `Indexes: ${numberFormatter.format(stats.indexes ?? 0)}`,
+        `Data Size: ${formatBytes(stats.dataSize)}`,
+        `Storage Size: ${formatBytes(stats.storageSize)}`,
+        `Index Size: ${formatBytes(stats.indexSize)}`,
+      ];
 
-      const embed = createEmbed({
-        title: 'MongoDB status',
-        color: 0x1f6feb,
-        fields: [
-          {
-            name: 'Connection',
-            value: 'Connected ✅',
-            inline: true,
-          },
-          {
-            name: 'Ping',
-            value: `${pingMs} ms`,
-            inline: true,
-          },
-          {
-            name: 'Database',
-            value: stats.db || 'Unknown',
-            inline: true,
-          },
-          {
-            name: 'Collections',
-            value: numberFormatter.format(stats.collections ?? 0),
-            inline: true,
-          },
-          {
-            name: 'Documents',
-            value: numberFormatter.format(stats.objects ?? 0),
-            inline: true,
-          },
-          {
-            name: 'Indexes',
-            value: numberFormatter.format(stats.indexes ?? 0),
-            inline: true,
-          },
-          {
-            name: 'Data Size',
-            value: formatBytes(stats.dataSize),
-            inline: true,
-          },
-          {
-            name: 'Storage Size',
-            value: formatBytes(stats.storageSize),
-            inline: true,
-          },
-          {
-            name: 'Index Size',
-            value: formatBytes(stats.indexSize),
-            inline: true,
-          },
-        ],
-      });
-
-      await interaction.editReply({ embeds: [embed] });
+      await interaction.editReply({ content: lines.join('\n') });
     } catch (error) {
-      const embed = createEmbed({
-        title: 'MongoDB status error',
-        description: `Failed to retrieve MongoDB statistics.\n\n\`\`\`${error.message}\`\`\``,
-        color: 0xed4245,
+      await interaction.editReply({
+        content: ['**MongoDB status error**', 'Failed to retrieve MongoDB statistics.', '```', error.message, '```'].join('\n'),
       });
-
-      await interaction.editReply({ embeds: [embed] });
     }
   },
 };

--- a/src/bot/services/gitMonitor.js
+++ b/src/bot/services/gitMonitor.js
@@ -65,6 +65,23 @@ class GitMonitor extends EventEmitter {
       throw error;
     }
   }
+
+  async getPendingCommitSummaries(status) {
+    const trackingRef = status?.tracking;
+    const currentRef = status?.current;
+
+    if (!trackingRef || !status || (status.behind ?? 0) === 0) {
+      return [];
+    }
+
+    try {
+      const log = await this.git.log({ from: currentRef || 'HEAD', to: trackingRef });
+      return log.all.map((entry) => `• ${entry.hash.slice(0, 7)} — ${entry.message}`).slice(0, 5);
+    } catch (error) {
+      this.logger.warn('Failed to load pending commit summaries:', error);
+      return [];
+    }
+  }
 }
 
 GitMonitor.UPDATE_CONFIRM_BUTTON_ID = UPDATE_CONFIRM_BUTTON_ID;


### PR DESCRIPTION
## Summary
- convert the /mongostats slash command to send concise text-based replies for status and error cases
- add commit summary details to repository update embeds so owners can see pending changes
- provide a helper on the git monitor service to gather pending commit summaries