### PR TITLE
Add owner power controls and reorganize commands

### DIFF
--- a/src/bot/bot.js
+++ b/src/bot/bot.js
@@ -35,6 +35,8 @@ class Bot extends EventEmitter {
     this.client.commandPrefix = this.config.commandPrefix;
     this.client.textCommands = this.textCommands;
     this.client.slashCommands = this.slashCommands;
+    this.client.requestRestart = () => this.emit('restartRequested');
+    this.client.requestShutdown = () => this.emit('shutdownRequested');
 
     this.gitMonitor = new GitMonitor({
       repoPath: process.cwd(),

--- a/src/bot/commands/common/power.js
+++ b/src/bot/commands/common/power.js
@@ -1,0 +1,458 @@
+const { randomUUID } = require('node:crypto');
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+
+const { createEmbed } = require('../../util/replies');
+
+const POWER_ACTIONS = {
+  RESTART: 'restart',
+  SHUTDOWN: 'shutdown',
+};
+
+const CUSTOM_ID_PREFIX = 'power';
+
+const SESSION_DURATION_MS = 60 * 1000;
+const COOLDOWN_AFTER_APPROVED_MS = 5 * 60 * 1000;
+const COOLDOWN_AFTER_CANCELLED_MS = 60 * 1000;
+const COOLDOWN_AFTER_EXPIRED_MS = 90 * 1000;
+
+const sessions = new Map();
+const actionSessions = new Map();
+const cooldowns = new Map();
+const history = new Map();
+
+function toSeconds(ms) {
+  return Math.floor(ms / 1000);
+}
+
+function formatRelative(ms) {
+  return `<t:${toSeconds(ms)}:R>`;
+}
+
+function formatAbsolute(ms) {
+  return `<t:${toSeconds(ms)}:f>`;
+}
+
+function getActionDisplay(action) {
+  return action === POWER_ACTIONS.SHUTDOWN ? 'Shutdown' : 'Restart';
+}
+
+function getActionColor(action) {
+  return action === POWER_ACTIONS.SHUTDOWN ? 0xed4245 : 0x5865f2;
+}
+
+function getResultColor(state) {
+  switch (state) {
+    case 'approved':
+      return 0x3ba55d;
+    case 'cancelled':
+      return 0xffa500;
+    case 'expired':
+    default:
+      return 0xfee75c;
+  }
+}
+
+function createCustomId(action, decision, sessionId) {
+  return `${CUSTOM_ID_PREFIX}:${action}:${decision}:${sessionId}`;
+}
+
+function parseCustomId(customId) {
+  if (!customId?.startsWith(`${CUSTOM_ID_PREFIX}:`)) {
+    return null;
+  }
+
+  const [, action, decision, sessionId] = customId.split(':');
+
+  if (!action || !decision || !sessionId) {
+    return null;
+  }
+
+  if (!Object.values(POWER_ACTIONS).includes(action)) {
+    return null;
+  }
+
+  if (!['confirm', 'cancel'].includes(decision)) {
+    return null;
+  }
+
+  return { action, decision, sessionId };
+}
+
+function getHistoryField(action) {
+  const record = history.get(action);
+
+  if (!record) {
+    return {
+      name: 'Last action',
+      value: 'No previous actions recorded.',
+    };
+  }
+
+  const descriptor = record.outcome === 'approved' ? 'Approved' : record.outcome === 'cancelled' ? 'Cancelled' : 'Expired';
+
+  const parts = [
+    `${descriptor} ${formatRelative(record.at)} (${formatAbsolute(record.at)})`,
+  ];
+
+  if (record.actorTag) {
+    parts.push(`Handled by **${record.actorTag}**.`);
+  }
+
+  if (record.reason) {
+    parts.push(record.reason);
+  }
+
+  return {
+    name: 'Last action',
+    value: parts.join('
+'),
+  };
+}
+
+function buildSessionPrompt(session) {
+  const actionDisplay = getActionDisplay(session.action);
+  const description = [
+    `**${session.requestedBy.tag}** requested a ${actionDisplay.toLowerCase()} of the bot.`,
+    'Use the buttons below to confirm or cancel the request.',
+    `This session expires ${formatRelative(session.expiresAt)} (${formatAbsolute(session.expiresAt)}).`,
+    `Session ID: \`${session.id}\``,
+  ].join('
+
+');
+
+  const fields = [
+    {
+      name: 'Requested by',
+      value: `<@${session.requestedBy.id}> (\`${session.requestedBy.tag}\`)`,
+      inline: true,
+    },
+    {
+      name: 'Opened',
+      value: `${formatRelative(session.createdAt)} (${formatAbsolute(session.createdAt)})`,
+      inline: true,
+    },
+    getHistoryField(session.action),
+  ];
+
+  const confirmLabel = session.action === POWER_ACTIONS.SHUTDOWN ? 'Confirm shutdown' : 'Confirm restart';
+  const confirmStyle = session.action === POWER_ACTIONS.SHUTDOWN ? ButtonStyle.Danger : ButtonStyle.Success;
+
+  const row = new ActionRowBuilder().addComponents(
+    new ButtonBuilder()
+      .setCustomId(createCustomId(session.action, 'confirm', session.id))
+      .setStyle(confirmStyle)
+      .setLabel(confirmLabel),
+    new ButtonBuilder()
+      .setCustomId(createCustomId(session.action, 'cancel', session.id))
+      .setStyle(ButtonStyle.Secondary)
+      .setLabel('Cancel request'),
+  );
+
+  return {
+    embeds: [
+      createEmbed({
+        title: `${actionDisplay} confirmation`,
+        description,
+        color: getActionColor(session.action),
+        timestamp: new Date(session.createdAt),
+        fields,
+      }),
+    ],
+    components: [row],
+  };
+}
+
+function buildActiveSessionEmbed(session) {
+  const actionDisplay = getActionDisplay(session.action);
+
+  return createEmbed({
+    title: `${actionDisplay} already pending`,
+    color: 0xfee75c,
+    description: [
+      `A ${actionDisplay.toLowerCase()} request from **${session.requestedBy.tag}** is already pending.`,
+      `It will expire ${formatRelative(session.expiresAt)} (${formatAbsolute(session.expiresAt)}).`,
+      'Resolve the existing request before starting a new one.',
+      `Session ID: \`${session.id}\``,
+    ].join('
+
+'),
+    fields: [
+      {
+        name: 'Requested by',
+        value: `<@${session.requestedBy.id}> (\`${session.requestedBy.tag}\`)`,
+        inline: true,
+      },
+      {
+        name: 'Opened',
+        value: `${formatRelative(session.createdAt)} (${formatAbsolute(session.createdAt)})`,
+        inline: true,
+      },
+    ],
+  });
+}
+
+function buildCooldownEmbed(action, endsAt) {
+  const actionDisplay = getActionDisplay(action);
+
+  return createEmbed({
+    title: `${actionDisplay} cooldown active`,
+    description: [
+      `A global cooldown is in effect for **${actionDisplay.toLowerCase()}** requests.`,
+      `You can initiate another request ${formatRelative(endsAt)} (${formatAbsolute(endsAt)}).`,
+    ].join('
+
+'),
+    color: 0xffa500,
+  });
+}
+
+function beginPowerSession({ action, userId, userTag }) {
+  const now = Date.now();
+  const cooldownUntil = cooldowns.get(action) ?? 0;
+
+  if (cooldownUntil > now) {
+    return { error: 'cooldown', embed: buildCooldownEmbed(action, cooldownUntil) };
+  }
+
+  const existingSessionId = actionSessions.get(action);
+  if (existingSessionId) {
+    const existingSession = sessions.get(existingSessionId);
+    if (existingSession) {
+      return { error: 'active', embed: buildActiveSessionEmbed(existingSession) };
+    }
+    actionSessions.delete(action);
+  }
+
+  const sessionId = randomUUID();
+  const createdAt = now;
+  const expiresAt = now + SESSION_DURATION_MS;
+  const session = {
+    id: sessionId,
+    action,
+    createdAt,
+    expiresAt,
+    requestedBy: {
+      id: userId,
+      tag: userTag,
+    },
+    status: 'pending',
+    message: null,
+    timeout: null,
+  };
+
+  const timeout = setTimeout(() => {
+    expireSession(sessionId);
+  }, SESSION_DURATION_MS);
+
+  if (typeof timeout.unref === 'function') {
+    timeout.unref();
+  }
+
+  session.timeout = timeout;
+
+  sessions.set(sessionId, session);
+  actionSessions.set(action, sessionId);
+
+  return { session, prompt: buildSessionPrompt(session) };
+}
+
+function registerSessionMessage(sessionId, message) {
+  const session = sessions.get(sessionId);
+  if (!session) {
+    return;
+  }
+
+  session.message = message;
+}
+
+function buildOutcomeEmbed(session, { state, actorTag, cooldownUntil, reason }) {
+  const actionDisplay = getActionDisplay(session.action);
+  const titleBase = state === 'approved' ? `${actionDisplay} approved` : state === 'cancelled' ? `${actionDisplay} cancelled` : `${actionDisplay} expired`;
+
+  const descriptionParts = [];
+
+  if (actorTag) {
+    const verb = state === 'approved' ? 'approved' : state === 'cancelled' ? 'cancelled' : 'allowed to expire';
+    descriptionParts.push(`**${actorTag}** ${verb} this request.`);
+  }
+
+  if (reason) {
+    descriptionParts.push(reason);
+  }
+
+  if (cooldownUntil && cooldownUntil > Date.now()) {
+    descriptionParts.push(`Global cooldown in effect until ${formatRelative(cooldownUntil)} (${formatAbsolute(cooldownUntil)}).`);
+  }
+
+  const fields = [
+    {
+      name: 'Requested by',
+      value: `<@${session.requestedBy.id}> (\`${session.requestedBy.tag}\`)`,
+      inline: true,
+    },
+    {
+      name: 'Opened',
+      value: `${formatRelative(session.createdAt)} (${formatAbsolute(session.createdAt)})`,
+      inline: true,
+    },
+  ];
+
+  return createEmbed({
+    title: titleBase,
+    description: descriptionParts.join('
+') || undefined,
+    color: getResultColor(state),
+    fields,
+    timestamp: new Date(),
+  });
+}
+
+function cleanupSession(sessionId) {
+  const session = sessions.get(sessionId);
+  if (!session) {
+    return null;
+  }
+
+  if (session.timeout) {
+    clearTimeout(session.timeout);
+    session.timeout = null;
+  }
+
+  sessions.delete(sessionId);
+
+  if (actionSessions.get(session.action) === sessionId) {
+    actionSessions.delete(session.action);
+  }
+
+  return session;
+}
+
+async function expireSession(sessionId) {
+  const session = cleanupSession(sessionId);
+  if (!session || session.status !== 'pending') {
+    return;
+  }
+
+  session.status = 'expired';
+
+  const cooldownUntil = Date.now() + COOLDOWN_AFTER_EXPIRED_MS;
+  cooldowns.set(session.action, cooldownUntil);
+  history.set(session.action, { at: Date.now(), outcome: 'expired', reason: 'No response before the session expired.' });
+
+  const embed = buildOutcomeEmbed(session, {
+    state: 'expired',
+    actorTag: null,
+    cooldownUntil,
+    reason: 'Request timed out before confirmation.',
+  });
+
+  if (session.message?.editable) {
+    try {
+      await session.message.edit({ embeds: [embed], components: [] });
+    } catch (error) {
+      // ignore edit errors for expired sessions
+    }
+  }
+}
+
+async function resolvePowerSession(sessionId, { approved, actor, client }) {
+  const session = sessions.get(sessionId);
+
+  if (!session || session.status !== 'pending') {
+    return { error: 'not-found' };
+  }
+
+  if (Date.now() > session.expiresAt) {
+    await expireSession(sessionId);
+    return { error: 'expired' };
+  }
+
+  cleanupSession(sessionId);
+
+  session.status = approved ? 'approved' : 'cancelled';
+
+  const now = Date.now();
+  const cooldownUntil = now + (approved ? COOLDOWN_AFTER_APPROVED_MS : COOLDOWN_AFTER_CANCELLED_MS);
+  cooldowns.set(session.action, cooldownUntil);
+
+  const actorTag = actor?.tag ?? 'Unknown user';
+  history.set(session.action, { at: now, actorTag, outcome: approved ? 'approved' : 'cancelled' });
+
+  const embed = buildOutcomeEmbed(session, {
+    state: approved ? 'approved' : 'cancelled',
+    actorTag,
+    cooldownUntil,
+  });
+
+  if (session.message?.editable) {
+    try {
+      await session.message.edit({ embeds: [embed], components: [] });
+    } catch (error) {
+      // ignore edit errors
+    }
+  }
+
+  if (approved) {
+    if (session.action === POWER_ACTIONS.RESTART) {
+      client?.requestRestart?.();
+    } else if (session.action === POWER_ACTIONS.SHUTDOWN) {
+      client?.requestShutdown?.();
+    }
+  }
+
+  return { embed };
+}
+
+async function cancelPowerSession(sessionId, { actor, reason }) {
+  const session = sessions.get(sessionId);
+
+  if (!session || session.status !== 'pending') {
+    return { error: 'not-found' };
+  }
+
+  cleanupSession(sessionId);
+
+  session.status = 'cancelled';
+
+  const now = Date.now();
+  const cooldownUntil = now + COOLDOWN_AFTER_CANCELLED_MS;
+  cooldowns.set(session.action, cooldownUntil);
+
+  const actorTag = actor?.tag ?? 'Unknown user';
+  history.set(session.action, { at: now, actorTag, outcome: 'cancelled', reason });
+
+  const embed = buildOutcomeEmbed(session, {
+    state: 'cancelled',
+    actorTag,
+    cooldownUntil,
+    reason,
+  });
+
+  if (session.message?.editable) {
+    try {
+      await session.message.edit({ embeds: [embed], components: [] });
+    } catch (error) {
+      // ignore edit errors
+    }
+  }
+
+  return { embed };
+}
+
+function getSession(sessionId) {
+  return sessions.get(sessionId);
+}
+
+module.exports = {
+  POWER_ACTIONS,
+  CUSTOM_ID_PREFIX,
+  beginPowerSession,
+  buildSessionPrompt,
+  registerSessionMessage,
+  buildCooldownEmbed,
+  buildActiveSessionEmbed,
+  parseCustomId,
+  resolvePowerSession,
+  cancelPowerSession,
+  getSession,
+};

--- a/src/bot/commands/slash/owner/reloadcommands.js
+++ b/src/bot/commands/slash/owner/reloadcommands.js
@@ -1,12 +1,14 @@
 const { SlashCommandBuilder, MessageFlags } = require('discord.js');
-const { createEmbed } = require('../../util/replies');
-const { isOwner } = require('../../util/owners');
-const { buildReloadActionRow } = require('../common/reloadCommands');
+const { createEmbed } = require('../../../util/replies');
+const { isOwner } = require('../../../util/owners');
+const { buildReloadActionRow } = require('../../common/reloadCommands');
 
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('reloadcommands')
     .setDescription('Reload the bot\'s slash commands.'),
+  category: 'owner',
+  ownerOnly: true,
   async execute(interaction) {
     if (!isOwner(interaction.user.id)) {
       await interaction.reply({

--- a/src/bot/commands/slash/owner/restart.js
+++ b/src/bot/commands/slash/owner/restart.js
@@ -1,0 +1,38 @@
+const { SlashCommandBuilder, MessageFlags } = require('discord.js');
+const { isOwner } = require('../../../util/owners');
+const { beginPowerSession, registerSessionMessage, POWER_ACTIONS } = require('../../common/power');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('restart')
+    .setDescription('Request a controlled bot restart with confirmation.'),
+  category: 'owner',
+  ownerOnly: true,
+  async execute(interaction) {
+    if (!isOwner(interaction.user.id)) {
+      await interaction.reply({
+        content: 'This command is restricted to bot owners.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const result = beginPowerSession({
+      action: POWER_ACTIONS.RESTART,
+      userId: interaction.user.id,
+      userTag: interaction.user.tag,
+    });
+
+    if (result.error) {
+      await interaction.reply({
+        embeds: [result.embed],
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    await interaction.reply(result.prompt);
+    const message = await interaction.fetchReply();
+    registerSessionMessage(result.session.id, message);
+  },
+};

--- a/src/bot/commands/slash/owner/setstatus.js
+++ b/src/bot/commands/slash/owner/setstatus.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder, MessageFlags } = require('discord.js');
-const { createEmbed } = require('../../util/replies');
-const { isOwner } = require('../../util/owners');
+const { createEmbed } = require('../../../util/replies');
+const { isOwner } = require('../../../util/owners');
 const {
   PRESENCE_STATUSES,
   ACTIVITY_TYPES,
@@ -8,7 +8,7 @@ const {
   normalizePresence,
   applyPresence,
   savePresence,
-} = require('../common/presence');
+} = require('../../common/presence');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -32,6 +32,8 @@ module.exports = {
         .setDescription('Activity text (e.g. Playing __).')
         .setMaxLength(128)
     ),
+  category: 'owner',
+  ownerOnly: true,
   async execute(interaction) {
     if (!isOwner(interaction.user.id)) {
       await interaction.reply({

--- a/src/bot/commands/slash/owner/shutdown.js
+++ b/src/bot/commands/slash/owner/shutdown.js
@@ -1,0 +1,38 @@
+const { SlashCommandBuilder, MessageFlags } = require('discord.js');
+const { isOwner } = require('../../../util/owners');
+const { beginPowerSession, registerSessionMessage, POWER_ACTIONS } = require('../../common/power');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('shutdown')
+    .setDescription('Initiate a graceful shutdown confirmation flow.'),
+  category: 'owner',
+  ownerOnly: true,
+  async execute(interaction) {
+    if (!isOwner(interaction.user.id)) {
+      await interaction.reply({
+        content: 'This command is restricted to bot owners.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const result = beginPowerSession({
+      action: POWER_ACTIONS.SHUTDOWN,
+      userId: interaction.user.id,
+      userTag: interaction.user.tag,
+    });
+
+    if (result.error) {
+      await interaction.reply({
+        embeds: [result.embed],
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    await interaction.reply(result.prompt);
+    const message = await interaction.fetchReply();
+    registerSessionMessage(result.session.id, message);
+  },
+};

--- a/src/bot/commands/text/owner/reloadcommands.js
+++ b/src/bot/commands/text/owner/reloadcommands.js
@@ -1,10 +1,12 @@
-const { replyWithEmbed, createEmbed } = require('../../util/replies');
-const { isOwner } = require('../../util/owners');
-const { buildReloadActionRow } = require('../common/reloadCommands');
+const { replyWithEmbed, createEmbed } = require('../../../util/replies');
+const { isOwner } = require('../../../util/owners');
+const { buildReloadActionRow } = require('../../common/reloadCommands');
 
 module.exports = {
   name: 'reloadcommands',
   description: 'Reload the bot\'s slash commands for this guild.',
+  category: 'owner',
+  ownerOnly: true,
   async execute({ message }) {
     if (!isOwner(message.author.id)) {
       await replyWithEmbed(message, {

--- a/src/bot/commands/text/owner/restart.js
+++ b/src/bot/commands/text/owner/restart.js
@@ -1,0 +1,38 @@
+const { replyWithEmbed } = require('../../../util/replies');
+const { isOwner } = require('../../../util/owners');
+const { beginPowerSession, registerSessionMessage, POWER_ACTIONS } = require('../../common/power');
+
+module.exports = {
+  name: 'restart',
+  description: 'Open a managed restart prompt with confirmation controls.',
+  category: 'owner',
+  ownerOnly: true,
+  async execute({ message }) {
+    if (!isOwner(message.author.id)) {
+      await replyWithEmbed(message, {
+        title: 'Owner only',
+        description: 'Only bot owners can request a restart.',
+        color: 0xed4245,
+      });
+      return;
+    }
+
+    const result = beginPowerSession({
+      action: POWER_ACTIONS.RESTART,
+      userId: message.author.id,
+      userTag: message.author.tag,
+    });
+
+    if (result.error) {
+      await replyWithEmbed(message, result.embed);
+      return;
+    }
+
+    const responseMessage = await message.reply({
+      ...result.prompt,
+      allowedMentions: { repliedUser: false },
+    });
+
+    registerSessionMessage(result.session.id, responseMessage);
+  },
+};

--- a/src/bot/commands/text/owner/shutdown.js
+++ b/src/bot/commands/text/owner/shutdown.js
@@ -1,0 +1,38 @@
+const { replyWithEmbed } = require('../../../util/replies');
+const { isOwner } = require('../../../util/owners');
+const { beginPowerSession, registerSessionMessage, POWER_ACTIONS } = require('../../common/power');
+
+module.exports = {
+  name: 'shutdown',
+  description: 'Initiate a graceful shutdown prompt with confirmations.',
+  category: 'owner',
+  ownerOnly: true,
+  async execute({ message }) {
+    if (!isOwner(message.author.id)) {
+      await replyWithEmbed(message, {
+        title: 'Owner only',
+        description: 'Only bot owners can shut down the bot.',
+        color: 0xed4245,
+      });
+      return;
+    }
+
+    const result = beginPowerSession({
+      action: POWER_ACTIONS.SHUTDOWN,
+      userId: message.author.id,
+      userTag: message.author.tag,
+    });
+
+    if (result.error) {
+      await replyWithEmbed(message, result.embed);
+      return;
+    }
+
+    const responseMessage = await message.reply({
+      ...result.prompt,
+      allowedMentions: { repliedUser: false },
+    });
+
+    registerSessionMessage(result.session.id, responseMessage);
+  },
+};

--- a/src/bot/util/help.js
+++ b/src/bot/util/help.js
@@ -1,35 +1,117 @@
 const { createEmbed } = require('./replies');
 
-function formatCommandList(commands, formatter, emptyFallback) {
-  if (!commands || commands.size === 0) {
+const CATEGORY_LABELS = {
+  general: 'General',
+  owner: 'Owner-Only',
+};
+
+const CATEGORY_ORDER = ['general', 'owner'];
+
+function toArray(commands) {
+  if (!commands) {
+    return [];
+  }
+
+  if (typeof commands.values === 'function') {
+    return Array.from(commands.values());
+  }
+
+  if (Array.isArray(commands)) {
+    return [...commands];
+  }
+
+  return [];
+}
+
+function normalizeCategory(command) {
+  if (command?.category) {
+    return String(command.category).toLowerCase();
+  }
+
+  if (command?.ownerOnly) {
+    return 'owner';
+  }
+
+  return 'general';
+}
+
+function getCategoryOrder(key) {
+  const normalized = key.toLowerCase();
+  const index = CATEGORY_ORDER.indexOf(normalized);
+  return index === -1 ? CATEGORY_ORDER.length : index;
+}
+
+function formatCategoryLabel(key) {
+  const normalized = key.toLowerCase();
+  if (CATEGORY_LABELS[normalized]) {
+    return CATEGORY_LABELS[normalized];
+  }
+
+  return normalized
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ');
+}
+
+function buildCategorizedList(commands, { getName, formatEntry, emptyFallback }) {
+  const items = toArray(commands);
+
+  if (!items.length) {
     return emptyFallback;
   }
 
-  return Array.from(commands.values())
-    .map(formatter)
-    .join('\n');
+  const categories = new Map();
+
+  for (const command of items) {
+    const key = normalizeCategory(command);
+    if (!categories.has(key)) {
+      categories.set(key, []);
+    }
+    categories.get(key).push(command);
+  }
+
+  const sections = Array.from(categories.entries())
+    .sort((a, b) => {
+      const orderDelta = getCategoryOrder(a[0]) - getCategoryOrder(b[0]);
+      if (orderDelta !== 0) {
+        return orderDelta;
+      }
+      return a[0].localeCompare(b[0]);
+    })
+    .map(([key, bucket]) => {
+      bucket.sort((left, right) => getName(left).localeCompare(getName(right)));
+      const entries = bucket.map(formatEntry).join('
+');
+      return `**${formatCategoryLabel(key)} Commands**
+${entries}`;
+    });
+
+  return sections.join('
+
+');
 }
 
 function buildHelpEmbed({ prefix = '!', textCommands, slashCommands }) {
-  const textValue = formatCommandList(
-    textCommands,
-    (command) => `\`${prefix}${command.name}\` - ${command.description || 'No description provided.'}`,
-    'No text commands are currently available.'
-  );
+  const textValue = buildCategorizedList(textCommands, {
+    getName: (command) => command.name,
+    formatEntry: (command) => `• \`${prefix}${command.name}\` - ${command.description || 'No description provided.'}`,
+    emptyFallback: 'No text commands are currently available.',
+  });
 
-  const slashValue = formatCommandList(
-    slashCommands,
-    (command) => {
+  const slashValue = buildCategorizedList(slashCommands, {
+    getName: (command) => command.data?.name ?? command.name,
+    formatEntry: (command) => {
       const name = command.data?.name ?? command.name;
       const description = command.data?.description ?? command.description;
-      return `\`/${name}\` - ${description || 'No description provided.'}`;
+      return `• \`/${name}\` - ${description || 'No description provided.'}`;
     },
-    'No slash commands are currently available.'
-  );
+    emptyFallback: 'No slash commands are currently available.',
+  });
 
   return createEmbed({
     title: 'Help menu',
-    description: 'Here\'s a list of commands you can use with the bot.',
+    description: 'Commands are grouped by scope. Owner-only actions appear in their own section.',
     fields: [
       { name: 'Text commands', value: textValue },
       { name: 'Slash commands', value: slashValue },

--- a/src/bot/util/replies.js
+++ b/src/bot/util/replies.js
@@ -27,7 +27,8 @@ function createEmbed(options = {}) {
   }
 
   if (timestamp) {
-    embed.setTimestamp(new Date());
+    const resolved = timestamp === true ? new Date() : timestamp;
+    embed.setTimestamp(resolved);
   }
 
   return embed;

--- a/src/worker.js
+++ b/src/worker.js
@@ -28,6 +28,11 @@ const RESTART_CODE = 5;
     await shutdown(RESTART_CODE);
   });
 
+  bot.on('shutdownRequested', async () => {
+    logger.info('Shutdown requested. Stopping bot without restart.');
+    await shutdown(0);
+  });
+
   process.on('SIGINT', () => shutdown(0));
   process.on('SIGTERM', () => shutdown(0));
 


### PR DESCRIPTION
## Summary
- add a reusable power-session manager that enforces confirmations, timers, cooldowns, and history for restart/shutdown requests
- introduce owner-only restart and shutdown commands for both text and slash interfaces while moving all owner commands into dedicated folders
- categorize help output, update loaders for nested folders, and wire client shutdown hooks plus button handling for the new workflows

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dedf5eac88832fa997a84dc5b5c639