### PR TITLE
Add text owners command and share utilities

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,5 +19,8 @@ GIT_POLL_INTERVAL_MINUTES=5
 # MongoDB connection URI
 MONGODB_URI=mongodb://localhost:27017/your_database_name
 
-# Comma-separated Discord user IDs allowed to run owner-only commands
+# Discord user ID allowed to manage the owner list via commands
+BOT_OWNER_MANAGER_ID=123456789012345678
+
+# (Optional) comma-separated Discord user IDs to seed as owners on first run
 BOT_OWNER_IDS=123456789012345678,987654321098765432

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This project provides a Discord bot written in JavaScript (Node.js) that support
 - **GitHub update monitor** that checks for new commits on the upstream branch and announces them in a fixed channel.
 - **One-click updates**: authorised users can confirm the update via a button, triggering `git pull`, `git push`, and a clean restart of the bot worker.
 - **MongoDB integration** with a reusable connection service and owner-only command to audit database health.
+- **Owner management** via MongoDB-backed slash and text commands restricted to a designated manager.
 - **Structured codebase** with clear separation of configuration, commands, events, services, and utilities.
 
 ## Getting started
@@ -45,7 +46,8 @@ This project provides a Discord bot written in JavaScript (Node.js) that support
    - `COMMAND_PREFIX`: Prefix for text commands (defaults to `!`).
    - `GIT_POLL_INTERVAL_MINUTES`: How often to poll for remote changes (defaults to 5 minutes).
    - `MONGODB_URI`: (Optional) MongoDB connection string used by the bot's database service.
-   - `BOT_OWNER_IDS`: Comma-separated Discord user IDs that should have access to owner-only commands (e.g. `/mongostats`).
+   - `BOT_OWNER_MANAGER_ID`: Discord user ID allowed to add or remove owners at runtime via `/owners` or `!owners`.
+   - `BOT_OWNER_IDS`: (Optional) Comma-separated Discord user IDs to seed as additional owners on first run.
 
 4. Deploy slash commands (run again whenever slash commands change):
 
@@ -85,8 +87,9 @@ src/
 ## MongoDB monitoring
 
 - Provide a MongoDB connection string via `MONGODB_URI` to enable the built-in database service.
-- Populate `BOT_OWNER_IDS` with the Discord user IDs that should have access to owner tooling.
+- (Optional) Populate `BOT_OWNER_IDS` with any Discord user IDs that should start with owner access.
 - Use the `/mongostats` slash command (owner-only) to verify connectivity, latency, and basic database metrics at runtime.
+- Configure `BOT_OWNER_MANAGER_ID` so that user can run `/owners` or `!owners` to review, add, or remove owners without restarting the bot.
 
 ## Adding commands
 
@@ -100,10 +103,12 @@ src/
 |---------|-------|-------------|
 | `!help` | Text  | Display the unified help menu with all commands. |
 | `!ping` | Text  | Check the bot's responsiveness. |
+| `!owners` | Text | Designated manager command to list, add, or remove bot owners (MongoDB required). |
 | `/help` | Slash | Display the unified help menu with all commands. |
 | `/ping` | Slash | Check the bot's responsiveness and latency. |
 | `/gitstatus` | Slash | Show the current Git status and pending updates. |
 | `/mongostats` | Slash | Owner-only command that validates MongoDB connectivity and displays database metrics. |
+| `/owners` | Slash | Designated manager command to list, add, or remove bot owners (MongoDB required). |
 
 ## License
 

--- a/src/bot/commands/slash/owners.js
+++ b/src/bot/commands/slash/owners.js
@@ -1,0 +1,166 @@
+const { SlashCommandBuilder, MessageFlags } = require('discord.js');
+const { createEmbed } = require('../../util/replies');
+const {
+  isOwnerManager,
+  ownerManagerId,
+  addOwner,
+  removeOwner,
+  syncOwnersFromDatabase,
+  getOwnerIds,
+  formatOwnerList,
+  parseUserIdInput,
+} = require('../../util/owners');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('owners')
+    .setDescription('Manage the list of bot owners.')
+    .addSubcommand((subcommand) =>
+      subcommand
+        .setName('add')
+        .setDescription('Add a Discord user as a bot owner.')
+        .addUserOption((option) =>
+          option.setName('user').setDescription('User to grant owner access to.').setRequired(true),
+        ),
+    )
+    .addSubcommand((subcommand) =>
+      subcommand
+        .setName('remove')
+        .setDescription('Remove a Discord user from the bot owner list.')
+        .addStringOption((option) =>
+          option
+            .setName('userid')
+            .setDescription('The Discord user ID to remove.')
+            .setMinLength(4)
+            .setRequired(true),
+        ),
+    )
+    .addSubcommand((subcommand) =>
+      subcommand.setName('list').setDescription('Display all Discord user IDs with owner access.'),
+    ),
+  async execute(interaction) {
+    if (!ownerManagerId) {
+      await interaction.reply({
+        content: 'An owner manager has not been configured. Set `BOT_OWNER_MANAGER_ID` before using this command.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (!isOwnerManager(interaction.user.id)) {
+      await interaction.reply({
+        content: 'Only the designated owner manager can update owner access.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const mongoService = interaction.client.mongoService;
+    if (!mongoService?.isConfigured?.()) {
+      await interaction.reply({
+        content: 'MongoDB must be configured before owners can be managed via commands.',
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    try {
+      await syncOwnersFromDatabase(mongoService);
+    } catch (error) {
+      await interaction.reply({
+        embeds: [
+          createEmbed({
+            title: 'Owner sync failed',
+            description: `Unable to load owners from MongoDB: ${error.message}`,
+            color: 0xed4245,
+          }),
+        ],
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const subcommand = interaction.options.getSubcommand();
+
+    if (subcommand === 'add') {
+      const user = interaction.options.getUser('user', true);
+
+      const result = await addOwner(mongoService, user.id, { addedBy: interaction.user.id });
+
+      const embed = createEmbed({
+        title: result.alreadyOwner ? 'Owner already exists' : 'Owner added',
+        description: result.alreadyOwner
+          ? `<@${user.id}> is already listed as a bot owner.`
+          : `<@${user.id}> has been added to the bot owner list.`,
+        color: result.alreadyOwner ? 0xffa500 : 0x3ba55d,
+      });
+
+      await interaction.reply({
+        embeds: [embed],
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (subcommand === 'remove') {
+      const rawInput = interaction.options.getString('userid', true);
+      const userId = parseUserIdInput(rawInput);
+      if (!userId) {
+        await interaction.reply({
+          embeds: [
+            createEmbed({
+              title: 'Invalid user ID',
+              description: 'Provide a valid Discord user ID or mention.',
+              color: 0xffa500,
+            }),
+          ],
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
+      const result = await removeOwner(mongoService, userId);
+
+      let embed;
+
+      if (result.isManager) {
+        embed = createEmbed({
+          title: 'Cannot remove manager',
+          description: 'The owner manager cannot remove their own access.',
+          color: 0xed4245,
+        });
+      } else if (result.notOwner) {
+        embed = createEmbed({
+          title: 'Owner not found',
+          description: `No owner entry was found for ID \`${userId}\`.`,
+          color: 0xffa500,
+        });
+      } else {
+        embed = createEmbed({
+          title: 'Owner removed',
+          description: `User ID \`${userId}\` has been removed from the owner list.`,
+          color: 0xed4245,
+        });
+      }
+
+      await interaction.reply({
+        embeds: [embed],
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (subcommand === 'list') {
+      const owners = getOwnerIds();
+      const embed = createEmbed({
+        title: 'Configured bot owners',
+        description: formatOwnerList(owners),
+        color: 0x5865f2,
+      });
+
+      await interaction.reply({
+        embeds: [embed],
+        flags: MessageFlags.Ephemeral,
+      });
+    }
+  },
+};

--- a/src/bot/commands/text/owners.js
+++ b/src/bot/commands/text/owners.js
@@ -1,0 +1,150 @@
+const { createEmbed, replyWithEmbed } = require('../../util/replies');
+const {
+  ownerManagerId,
+  isOwnerManager,
+  syncOwnersFromDatabase,
+  getOwnerIds,
+  addOwner,
+  removeOwner,
+  formatOwnerList,
+  parseUserIdInput,
+} = require('../../util/owners');
+
+const EMBED_COLORS = {
+  info: 0x5865f2,
+  success: 0x3ba55d,
+  warning: 0xffa500,
+  danger: 0xed4245,
+};
+
+module.exports = {
+  name: 'owners',
+  description: 'Manage the list of bot owners (restricted to the owner manager).',
+  usage: '!owners <list|add|remove> [user]',
+  async execute({ message, args }) {
+    if (!ownerManagerId) {
+      await replyWithEmbed(message, {
+        title: 'Owner manager not configured',
+        description: 'Set `BOT_OWNER_MANAGER_ID` in the environment before using this command.',
+        color: EMBED_COLORS.danger,
+      });
+      return;
+    }
+
+    if (!isOwnerManager(message.author.id)) {
+      await replyWithEmbed(message, {
+        title: 'Access denied',
+        description: 'Only the designated owner manager can update the owner list.',
+        color: EMBED_COLORS.danger,
+      });
+      return;
+    }
+
+    const mongoService = message.client.mongoService;
+    if (!mongoService?.isConfigured?.()) {
+      await replyWithEmbed(message, {
+        title: 'MongoDB required',
+        description: 'Configure MongoDB before attempting to manage owners.',
+        color: EMBED_COLORS.warning,
+      });
+      return;
+    }
+
+    try {
+      await syncOwnersFromDatabase(mongoService);
+    } catch (error) {
+      await replyWithEmbed(message, {
+        title: 'Owner sync failed',
+        description: `Unable to load owners from MongoDB: ${error.message}`,
+        color: EMBED_COLORS.danger,
+      });
+      return;
+    }
+
+    const subcommandInput = args.shift();
+    const subcommand = subcommandInput ? subcommandInput.toLowerCase() : 'list';
+
+    if (subcommand === 'list') {
+      const owners = getOwnerIds();
+      await replyWithEmbed(message, {
+        title: 'Configured bot owners',
+        description: formatOwnerList(owners),
+        color: EMBED_COLORS.info,
+      });
+      return;
+    }
+
+    if (subcommand === 'add') {
+      const mention = message.mentions.users.first();
+      const rawInput = mention ? mention.id : args.shift();
+      const userId = mention ? mention.id : parseUserIdInput(rawInput);
+
+      if (!userId) {
+        await replyWithEmbed(message, {
+          title: 'Invalid user',
+          description: 'Provide a valid Discord user ID or mention to add as an owner.',
+          color: EMBED_COLORS.warning,
+        });
+        return;
+      }
+
+      const result = await addOwner(mongoService, userId, { addedBy: message.author.id });
+
+      await replyWithEmbed(message, {
+        title: result.alreadyOwner ? 'Owner already exists' : 'Owner added',
+        description: result.alreadyOwner
+          ? `<@${userId}> is already listed as a bot owner.`
+          : `<@${userId}> has been added to the bot owner list.`,
+        color: result.alreadyOwner ? EMBED_COLORS.warning : EMBED_COLORS.success,
+      });
+      return;
+    }
+
+    if (subcommand === 'remove') {
+      const mention = message.mentions.users.first();
+      const rawInput = mention ? mention.id : args.shift();
+      const userId = mention ? mention.id : parseUserIdInput(rawInput);
+
+      if (!userId) {
+        await replyWithEmbed(message, {
+          title: 'Invalid user',
+          description: 'Provide a valid Discord user ID or mention to remove.',
+          color: EMBED_COLORS.warning,
+        });
+        return;
+      }
+
+      const result = await removeOwner(mongoService, userId);
+
+      let embed;
+      if (result.isManager) {
+        embed = createEmbed({
+          title: 'Cannot remove manager',
+          description: 'The owner manager cannot remove their own access.',
+          color: EMBED_COLORS.danger,
+        });
+      } else if (result.notOwner) {
+        embed = createEmbed({
+          title: 'Owner not found',
+          description: `No owner entry was found for ID \`${userId}\`.`,
+          color: EMBED_COLORS.warning,
+        });
+      } else {
+        embed = createEmbed({
+          title: 'Owner removed',
+          description: `User ID \`${userId}\` has been removed from the owner list.`,
+          color: EMBED_COLORS.danger,
+        });
+      }
+
+      await replyWithEmbed(message, embed);
+      return;
+    }
+
+    await replyWithEmbed(message, {
+      title: 'Unknown subcommand',
+      description: 'Use `list`, `add`, or `remove` when managing owners.',
+      color: EMBED_COLORS.warning,
+    });
+  },
+};

--- a/src/bot/events/ready.js
+++ b/src/bot/events/ready.js
@@ -1,4 +1,5 @@
 const { fetchStoredPresence, applyPresence, buildPresenceDescription } = require('../commands/common/presence');
+const { syncOwnersFromDatabase } = require('../util/owners');
 
 module.exports = ({ client, logger, slashCommands, mongoService }) => {
   client.once('clientReady', async () => {
@@ -7,6 +8,16 @@ module.exports = ({ client, logger, slashCommands, mongoService }) => {
 
     if (!mongoService) {
       return;
+    }
+
+    if (mongoService?.isConfigured?.()) {
+      try {
+        const ownerIds = await syncOwnersFromDatabase(mongoService);
+        const ownerCount = ownerIds.length;
+        logger.info(`Loaded ${ownerCount} owner ${ownerCount === 1 ? 'ID' : 'IDs'} from MongoDB.`);
+      } catch (error) {
+        logger.warn(`Failed to synchronize owner IDs from MongoDB: ${error.message}`);
+      }
     }
 
     try {

--- a/src/bot/util/owners.js
+++ b/src/bot/util/owners.js
@@ -1,16 +1,203 @@
 const config = require('../../config');
 
-const ownerIdSet = new Set(config.ownerIds || []);
+const COLLECTION_NAME = 'owners';
+
+const initialOwnerIds = Array.isArray(config.ownerIds) ? [...new Set(config.ownerIds)] : [];
+const ownerManagerId = config.ownerManagerId || '';
+
+if (ownerManagerId && !initialOwnerIds.includes(ownerManagerId)) {
+  initialOwnerIds.push(ownerManagerId);
+}
+
+const ownerIdSet = new Set(initialOwnerIds);
+
+function normalizeUserId(userId) {
+  if (typeof userId === 'string') {
+    return userId.trim();
+  }
+
+  if (userId === null || userId === undefined) {
+    return '';
+  }
+
+  return String(userId).trim();
+}
+
+async function getOwnersCollection(mongoService) {
+  if (!mongoService?.isConfigured?.()) {
+    throw new Error('MongoDB is not configured.');
+  }
+
+  const client = await mongoService.ensureConnection();
+  if (!client) {
+    throw new Error('MongoDB client is not available.');
+  }
+
+  return client.db().collection(COLLECTION_NAME);
+}
 
 function isOwner(userId) {
-  if (!userId) {
+  const normalized = normalizeUserId(userId);
+  if (!normalized) {
     return false;
   }
 
-  return ownerIdSet.has(userId);
+  return ownerIdSet.has(normalized);
+}
+
+function isOwnerManager(userId) {
+  const normalized = normalizeUserId(userId);
+  if (!normalized || !ownerManagerId) {
+    return false;
+  }
+
+  return normalized === ownerManagerId;
+}
+
+function getOwnerIds() {
+  return Array.from(ownerIdSet.values());
+}
+
+function formatOwnerList(ownerIds) {
+  if (!Array.isArray(ownerIds) || ownerIds.length === 0) {
+    return 'No owners are currently configured.';
+  }
+
+  const sorted = [...new Set(ownerIds)].sort((a, b) => a.localeCompare(b));
+
+  return sorted
+    .map((id) => {
+      const isManager = ownerManagerId && id === ownerManagerId;
+      return `• ${id}${isManager ? ' *(manager)*' : ''}`;
+    })
+    .join('\n');
+}
+
+function parseUserIdInput(input) {
+  if (!input) {
+    return '';
+  }
+
+  const trimmed = input.trim();
+  const mentionMatch = trimmed.match(/^<@!?([0-9]{3,})>$/);
+
+  if (mentionMatch) {
+    return mentionMatch[1];
+  }
+
+  if (/^[0-9]{3,}$/.test(trimmed)) {
+    return trimmed;
+  }
+
+  return '';
+}
+
+async function syncOwnersFromDatabase(mongoService) {
+  const collection = await getOwnersCollection(mongoService);
+  let documents = await collection.find({}).toArray();
+
+  if (!documents.length && ownerIdSet.size > 0) {
+    const seedIds = Array.from(ownerIdSet.values());
+    const operations = seedIds.map((id) => ({
+      updateOne: {
+        filter: { _id: id },
+        update: {
+          $setOnInsert: {
+            _id: id,
+            addedAt: new Date(),
+            addedBy: ownerManagerId || 'config',
+          },
+        },
+        upsert: true,
+      },
+    }));
+
+    if (operations.length) {
+      await collection.bulkWrite(operations, { ordered: false });
+      documents = await collection.find({}).toArray();
+    }
+  }
+
+  const nextOwnerIds = new Set();
+
+  for (const document of documents) {
+    const normalized = normalizeUserId(document?._id);
+    if (normalized) {
+      nextOwnerIds.add(normalized);
+    }
+  }
+
+  if (ownerManagerId) {
+    nextOwnerIds.add(ownerManagerId);
+  }
+
+  ownerIdSet.clear();
+  for (const id of nextOwnerIds) {
+    ownerIdSet.add(id);
+  }
+
+  return getOwnerIds();
+}
+
+async function addOwner(mongoService, userId, { addedBy } = {}) {
+  const normalized = normalizeUserId(userId);
+  if (!normalized) {
+    throw new Error('A user ID is required to add an owner.');
+  }
+
+  if (ownerIdSet.has(normalized)) {
+    return { alreadyOwner: true, ownerIds: getOwnerIds() };
+  }
+
+  const collection = await getOwnersCollection(mongoService);
+  await collection.updateOne(
+    { _id: normalized },
+    {
+      $setOnInsert: {
+        _id: normalized,
+        addedAt: new Date(),
+        ...(addedBy ? { addedBy } : {}),
+      },
+    },
+    { upsert: true },
+  );
+
+  ownerIdSet.add(normalized);
+
+  return { alreadyOwner: false, ownerIds: getOwnerIds() };
+}
+
+async function removeOwner(mongoService, userId) {
+  const normalized = normalizeUserId(userId);
+  if (!normalized) {
+    throw new Error('A user ID is required to remove an owner.');
+  }
+
+  if (normalized === ownerManagerId) {
+    return { isManager: true, ownerIds: getOwnerIds() };
+  }
+
+  if (!ownerIdSet.has(normalized)) {
+    return { notOwner: true, ownerIds: getOwnerIds() };
+  }
+
+  const collection = await getOwnersCollection(mongoService);
+  await collection.deleteOne({ _id: normalized });
+
+  ownerIdSet.delete(normalized);
+
+  return { removed: true, ownerIds: getOwnerIds() };
 }
 
 module.exports = {
   ownerIdSet,
+  ownerManagerId,
   isOwner,
+  isOwnerManager,
+  getOwnerIds,
+  formatOwnerList,
+  parseUserIdInput,
+  syncOwnersFromDatabase,
+  addOwner,
+  removeOwner,
 };

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -16,6 +16,7 @@ const config = {
   commandPrefix: process.env.COMMAND_PREFIX || '!',
   gitPollIntervalMinutes: numberFromEnv(process.env.GIT_POLL_INTERVAL_MINUTES, 5),
   mongoUri: process.env.MONGODB_URI || '',
+  ownerManagerId: process.env.BOT_OWNER_MANAGER_ID || '',
   ownerIds: (process.env.BOT_OWNER_IDS || '')
     .split(',')
     .map((id) => id.trim())


### PR DESCRIPTION
## Summary
- add a manager-only `!owners` text command that mirrors the Mongo-backed owner management workflow
- centralize owner formatting and ID parsing helpers for reuse and improve slash command error handling
- document the optional owner seeding env var and the new text command in the README and example env file

## Testing
- node -e "require('./src/bot/commands/slash/owners.js'); require('./src/bot/commands/text/owners.js');"

------
https://chatgpt.com/codex/tasks/task_e_68e569d10c4c832f96f687c47b84a3da